### PR TITLE
Settings: Squashed commit for expanded desktop

### DIFF
--- a/res/drawable/expanded_close_bg.xml
+++ b/res/drawable/expanded_close_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="#40607D8B">
+</ripple>

--- a/res/drawable/expanded_item_background.xml
+++ b/res/drawable/expanded_item_background.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-     Copyright (C) 2012-2013 The CyanogenMod Project
+<!-- Copyright (C) 2013 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,7 +13,9 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
-    <dimen name="profile_instruction_padding">8dp</dimen>
-    <dimen name="fab_line_width">2dp</dimen>
-</resources>
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_activated="true" android:drawable="@drawable/expanded_item_bg_activated" />
+    <item android:state_activated="false" android:drawable="@drawable/expanded_item_bg" />
+</selector>
+

--- a/res/drawable/ic_settings_extdesk_hideboth.xml
+++ b/res/drawable/ic_settings_extdesk_hideboth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright (C) 2012-2013 The CyanogenMod Project
+     Copyright (C) 2012-2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,7 +14,14 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
-    <dimen name="profile_instruction_padding">8dp</dimen>
-    <dimen name="fab_line_width">2dp</dimen>
-</resources>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#039588"
+        android:pathData="M18,4v16H6V4H18
+M18,2H6C4.9,2,4,2.9,4,4v16c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2V4C20,2.9,19.1,2,18,2L18,2Z" />
+</vector>

--- a/res/drawable/ic_settings_extdesk_hidenone.xml
+++ b/res/drawable/ic_settings_extdesk_hidenone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright (C) 2012-2013 The CyanogenMod Project
+     Copyright (C) 2012-2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,7 +14,14 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
-    <dimen name="profile_instruction_padding">8dp</dimen>
-    <dimen name="fab_line_width">2dp</dimen>
-</resources>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#039588"
+        android:pathData="M6,8h12v8H6V8Z
+M6,22h12c1.1,0,2-0.9,2-2V4c0-1.1-0.9-2-2-2H6C4.9,2,4,2.9,4,4v16C4,21.1,4.9,22,6,22L6,22z" />
+</vector>

--- a/res/drawable/ic_settings_extdesk_hidestatusbar.xml
+++ b/res/drawable/ic_settings_extdesk_hidestatusbar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright (C) 2012-2013 The CyanogenMod Project
+     Copyright (C) 2012-2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,7 +14,14 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
-    <dimen name="profile_instruction_padding">8dp</dimen>
-    <dimen name="fab_line_width">2dp</dimen>
-</resources>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#039588"
+        android:pathData="M6,4h12v12H6V4Z
+M6,22h12c1.1,0,2-0.9,2-2V4c0-1.1-0.9-2-2-2H6C4.9,2,4,2.9,4,4v16C4,21.1,4.9,22,6,22L6,22z" />
+</vector>

--- a/res/layout/expanded_desktop.xml
+++ b/res/layout/expanded_desktop.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2012-2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+     android:layout_width="match_parent"
+     android:layout_height="match_parent">
+    <FrameLayout
+            android:id="@+id/extra_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    <ListView
+            android:id="@+id/user_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:scrollbarStyle="@*android:integer/preference_fragment_scrollbarStyle"/>
+    <ProgressBar
+            android:id="@+id/progress_bar"
+            style="@android:style/Widget.Material.ProgressBar.Large"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true" />
+    <TextView
+            android:id="@+id/nothing_to_show"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="@string/expanded_nothing_to_show"
+            android:visibility="gone" />
+</RelativeLayout>

--- a/res/layout/expanded_item.xml
+++ b/res/layout/expanded_item.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2012-2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:paddingTop="8dip"
+    android:paddingBottom="8dip"
+    android:orientation="horizontal"
+    android:background="@drawable/expanded_item_background">
+
+    <ImageView
+        android:id="@+id/app_icon"
+        android:layout_width="@android:dimen/app_icon_size"
+        android:layout_height="@android:dimen/app_icon_size"
+        android:layout_marginEnd="8dip"
+        android:layout_gravity="center_vertical"
+        android:scaleType="centerInside"
+        android:contentDescription="@null" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:orientation="vertical" >
+
+        <TextView
+            android:id="@+id/app_name"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_gravity="fill_horizontal"
+            android:layout_marginTop="2dip"
+            android:singleLine="true"
+            android:ellipsize="marquee"
+            android:textColor="@android:color/black"
+            android:textAppearance="@style/TextAppearance.Medium"
+            android:textAlignment="viewStart" />
+
+        <Spinner
+            android:id="@+id/app_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal|top"
+            android:textAppearance="@style/TextAppearance.Small"
+            android:textAlignment="viewStart" />
+
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/state"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_settings_extdesk_hidenone" />
+</LinearLayout>

--- a/res/menu/expanded_desktop.xml
+++ b/res/menu/expanded_desktop.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/enable_for_all"
+        android:title="Enable for all" />
+
+    <item
+        android:id="@+id/user_configurable"
+        android:title="User configurable" />
+
+    <item
+        android:id="@+id/disable_for_all"
+        android:title="Disable for all" />
+</menu>

--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -379,4 +379,16 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+
+    <string-array name="expanded_desktop_entries" translatable="false">
+        <item>@string/expanded_hide_both</item>
+        <item>@string/expanded_hide_status</item>
+        <item>@string/expanded_hide_navigation</item>
+    </string-array>
+
+    <string-array name="expanded_desktop_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 </resources>

--- a/res/values/cm_colors.xml
+++ b/res/values/cm_colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (C) 2014 The CyanogenMod Project
+Copyright (C) 2015 The CyanogenMod Project
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ limitations under the License.
     <drawable name="expanded_item_bg">@android:color/background_light</drawable>
     <color name="expanded_button_color_normal">#4CAF50</color>
     <color name="expanded_button_color_close">#F44336</color>
+
     <color name="qs_tile_tint_color">#FF009587</color>
 
     <!-- Hard coded background and text colors exposed for better theme support -->

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -682,4 +682,19 @@
     <!-- Advanced reboot options -->
     <string name="advanced_reboot_title">Advanced reboot</string>
     <string name="advanced_reboot_summary">When unlocked, include options in the power menu for rebooting into recovery, bootloader or performing a soft reboot</string>
+
+    <string name="category_interface">Interface</string>
+    <!-- Expanded desktop -->
+    <string name="power_menu_expanded_desktop">Expanded desktop</string>
+    <string name="expanded_hide_nothing">Hide nothing</string>
+    <string name="expanded_hide_status">Hide status bar</string>
+    <string name="expanded_hide_navigation">Hide navigation bar</string>
+    <string name="expanded_hide_both">Hide both</string>
+    <string name="expanded_nothing_to_show">To add a custom per-app configuration for expanded state, set "Enabled for all" to the off position</string>
+    <string name="expanded_desktop_state">Expanded state</string>
+    <string name="expanded_enabled_for_all">Enabled for all</string>
+    <string name="expanded_user_configurable">User configurable</string>
+    <string name="expanded_desktop_style">Expanded desktop style</string>
+    <string name="expanded_desktop_style_description">Choose a default expanded desktop style</string>
+    <string name="expanded_desktop_title">Expanded desktop options</string>
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -129,6 +129,16 @@
                 android:fragment="com.android.settings.wfd.WifiDisplaySettings" />
 
         <PreferenceCategory
+                android:key="interface"
+                android:title="@string/category_interface">
+                <!-- expanded desktop -->
+                <PreferenceScreen
+                        android:key="expanded_desktop"
+                        android:title="@string/power_menu_expanded_desktop"
+                        android:fragment="com.android.settings.applications.ExpandedDesktopPreferenceFragment" />
+        </PreferenceCategory>
+
+        <PreferenceCategory
                 android:key="advanced_display_prefs"
                 android:title="@string/advanced_settings">
 

--- a/res/xml/expanded_desktop_prefs.xml
+++ b/res/xml/expanded_desktop_prefs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-     Copyright (C) 2012-2013 The CyanogenMod Project
+<!-- Copyright (C) 2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,7 +13,14 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
-    <dimen name="profile_instruction_padding">8dp</dimen>
-    <dimen name="fab_line_width">2dp</dimen>
-</resources>
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory
+            android:title="@string/expanded_desktop_title" >
+        <ListPreference
+                android:key="expanded_desktop_style"
+                android:title="@string/expanded_desktop_style"
+                android:entries="@array/expanded_desktop_entries"
+                android:entryValues="@array/expanded_desktop_values"/>
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/src/com/android/settings/applications/ExpandedDesktopExtraPrefs.java
+++ b/src/com/android/settings/applications/ExpandedDesktopExtraPrefs.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.applications;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Bundle;
+
+import android.os.Handler;
+import android.preference.ListPreference;
+import android.preference.Preference;
+import android.provider.Settings;
+import android.view.WindowManager;
+import android.view.WindowManagerPolicyControl;
+
+import com.android.internal.logging.MetricsLogger;
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.settings.R;
+
+public class ExpandedDesktopExtraPrefs extends SettingsPreferenceFragment
+        implements Preference.OnPreferenceChangeListener{
+    private static final String KEY_EXPANDED_DESKTOP_STYLE = "expanded_desktop_style";
+
+    private ListPreference mExpandedDesktopStylePref;
+    private int mExpandedDesktopStyle;
+    private final Handler mHandler = new Handler();
+    private final SettingsObserver mSettingsObserver = new SettingsObserver();
+
+    public static ExpandedDesktopExtraPrefs newInstance() {
+        ExpandedDesktopExtraPrefs expandedDesktopExtraPrefs = new ExpandedDesktopExtraPrefs();
+        return expandedDesktopExtraPrefs;
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.expanded_desktop_prefs);
+        mExpandedDesktopStyle = getExpandedDesktopStyle();
+        createPreferences();
+    }
+
+    @Override
+    protected int getMetricsCategory() {
+        return MetricsLogger.DISPLAY;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mSettingsObserver.register(true);
+    }
+
+    @Override
+    public void onPause() {
+        mSettingsObserver.register(false);
+        super.onPause();
+    }
+
+    public void createPreferences() {
+        mExpandedDesktopStylePref = (ListPreference) findPreference(KEY_EXPANDED_DESKTOP_STYLE);
+        mExpandedDesktopStylePref.setOnPreferenceChangeListener(this);
+        updateExpandedDesktopStyle();
+    }
+
+    private void updateExpandedDesktopStyle() {
+        if (mExpandedDesktopStylePref == null) {
+            return;
+        }
+        mExpandedDesktopStyle = getExpandedDesktopStyle();
+        mExpandedDesktopStylePref.setValueIndex(mExpandedDesktopStyle);
+        mExpandedDesktopStylePref.setSummary(getDesktopSummary(mExpandedDesktopStyle));
+        // We need to visually show the change
+        // TODO: This is hacky, but it works
+        writeValue("");
+        writeValue("immersive.full=*");
+    }
+
+    private int getDesktopSummary(int state) {
+        switch (state) {
+            case WindowManagerPolicyControl.ImmersiveDefaultStyles.IMMERSIVE_STATUS:
+                return R.string.expanded_hide_status;
+            case WindowManagerPolicyControl.ImmersiveDefaultStyles.IMMERSIVE_NAVIGATION:
+                return R.string.expanded_hide_navigation;
+            case WindowManagerPolicyControl.ImmersiveDefaultStyles.IMMERSIVE_FULL:
+            default:
+                return R.string.expanded_hide_both;
+        }
+    }
+
+    private int getExpandedDesktopStyle() {
+        return Settings.Global.getInt(getContentResolver(),
+                Settings.Global.POLICY_CONTROL_STYLE,
+                WindowManagerPolicyControl.ImmersiveDefaultStyles.IMMERSIVE_FULL);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final int val = Integer.valueOf((String) value);
+        WindowManagerPolicyControl.saveStyleToSettings(getActivity(), val);
+        return false;
+    }
+
+    private void writeValue(String value) {
+        Settings.Global.putString(getContentResolver(), Settings.Global.POLICY_CONTROL, value);
+    }
+
+    // === Window Policy Style Callbacks ===
+
+    private final class SettingsObserver extends ContentObserver {
+        private final Uri DEFAULT_WINDOW_POLICY_STYLE =
+                Settings.Global.getUriFor(Settings.Global.POLICY_CONTROL_STYLE);
+
+        public SettingsObserver() {
+            super(mHandler);
+        }
+
+        public void register(boolean register) {
+            final ContentResolver cr = getContentResolver();
+            if (register) {
+                cr.registerContentObserver(DEFAULT_WINDOW_POLICY_STYLE, false, this);
+            } else {
+                cr.unregisterContentObserver(this);
+            }
+        }
+
+        @Override
+        public void onChange(boolean selfChange, Uri uri) {
+            super.onChange(selfChange, uri);
+            if (DEFAULT_WINDOW_POLICY_STYLE.equals(uri)) {
+                updateExpandedDesktopStyle();
+            }
+        }
+    }
+}

--- a/src/com/android/settings/applications/ExpandedDesktopPreferenceFragment.java
+++ b/src/com/android/settings/applications/ExpandedDesktopPreferenceFragment.java
@@ -1,0 +1,614 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settings.applications;
+
+import android.annotation.Nullable;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.os.Bundle;
+import android.os.RemoteException;
+import android.provider.Settings;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManagerGlobal;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.ListView;
+import android.widget.SectionIndexer;
+import android.widget.Spinner;
+import android.widget.Switch;
+import android.widget.TextView;
+import android.view.WindowManagerPolicyControl;
+import com.android.internal.logging.MetricsLogger;
+import com.android.settings.R;
+import com.android.settings.SettingsActivity;
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.settings.widget.SwitchBar;
+import com.android.settingslib.applications.ApplicationsState;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ExpandedDesktopPreferenceFragment extends SettingsPreferenceFragment
+        implements AdapterView.OnItemClickListener, ApplicationsState.Callbacks,
+        SwitchBar.OnSwitchChangeListener {
+
+    private static final int STATE_DISABLED = 0;
+    private static final int STATE_STATUS_HIDDEN = 1;
+    private static final int STATE_NAVIGATION_HIDDEN = 2;
+    private static final int STATE_BOTH_HIDDEN = 3;
+
+    private static final int STATE_ENABLE_FOR_ALL = 0;
+    private static final int STATE_USER_CONFIGURABLE = 1;
+
+    private static final String EXPANDED_DESKTOP_PREFERENCE_TAG = "desktop_prefs";
+
+    private AllPackagesAdapter mAllPackagesAdapter;
+    private ApplicationsState mApplicationsState;
+    private View mEmptyView;
+    private View mProgressBar;
+    private ListView mUserListView;
+    private FrameLayout mExtraOptions;
+    private ApplicationsState.Session mSession;
+    private ActivityFilter mActivityFilter;
+    private Map<String, ApplicationsState.AppEntry> mEntryMap =
+            new HashMap<String, ApplicationsState.AppEntry>();
+    private int mExpandedDesktopState;
+    private SwitchBar mSwitchBar;
+
+    private int getExpandedDesktopState(ContentResolver cr) {
+        String value = Settings.Global.getString(cr, Settings.Global.POLICY_CONTROL);
+        if ("immersive.full=*".equals(value)) {
+            return STATE_ENABLE_FOR_ALL;
+        }
+        return STATE_USER_CONFIGURABLE;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mApplicationsState = ApplicationsState.getInstance(getActivity().getApplication());
+        mSession = mApplicationsState.newSession(this);
+        mSession.resume();
+        mActivityFilter = new ActivityFilter(getActivity().getPackageManager());
+
+        mExpandedDesktopState = getExpandedDesktopState(getActivity().getContentResolver());
+        if (mExpandedDesktopState == STATE_USER_CONFIGURABLE) {
+            WindowManagerPolicyControl.reloadFromSetting(getActivity(),
+                    Settings.Global.POLICY_CONTROL);
+        }
+        mAllPackagesAdapter = new AllPackagesAdapter(getActivity());
+
+        mAllPackagesAdapter.notifyDataSetChanged();
+
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    protected int getMetricsCategory() {
+        return MetricsLogger.DISPLAY;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        rebuild();
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.expanded_desktop, container, false);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        save();
+        mSession.pause();
+        mSession.release();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (mSwitchBar != null) {
+            mSwitchBar.removeOnSwitchChangeListener(this);
+        }
+    }
+
+    @Override
+    public void onViewCreated(final View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        mUserListView = (ListView) view.findViewById(R.id.user_list_view);
+        mExtraOptions = (FrameLayout) view.findViewById(R.id.extra_content);
+        mUserListView.setAdapter(mAllPackagesAdapter);
+        mUserListView.setFastScrollEnabled(true);
+        mUserListView.setOnItemClickListener(this);
+
+        mSwitchBar = ((SettingsActivity) getActivity()).getSwitchBar();
+        mSwitchBar.addOnSwitchChangeListener(this);
+        mSwitchBar.setOnStateOffLabel(R.string.expanded_enabled_for_all);
+        mSwitchBar.setOnStateOnLabel(R.string.expanded_enabled_for_all);
+        mSwitchBar.show();
+
+        mEmptyView = view.findViewById(R.id.nothing_to_show);
+        mProgressBar = view.findViewById(R.id.progress_bar);
+
+        if (mExpandedDesktopState == STATE_USER_CONFIGURABLE) {
+            mSwitchBar.setChecked(false);
+            showListView();
+            mExtraOptions.setVisibility(View.GONE);
+        } else {
+            mSwitchBar.setChecked(true);
+            mProgressBar.setVisibility(View.GONE);
+            hideListView();
+            mExtraOptions.setVisibility(View.VISIBLE);
+        }
+    }
+
+    @Override
+    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        ViewHolder holder = (ViewHolder) view.getTag();
+        holder.mode.performClick();
+    }
+
+    private void enableForAll() {
+        mExpandedDesktopState = STATE_ENABLE_FOR_ALL;
+        writeValue("immersive.full=*");
+        mAllPackagesAdapter.notifyDataSetInvalidated();
+        hideListView();
+        transactFragment();
+        mExtraOptions.setVisibility(View.VISIBLE);
+    }
+
+    private void userConfigurableSettings() {
+        mExpandedDesktopState = STATE_USER_CONFIGURABLE;
+        writeValue("");
+        WindowManagerPolicyControl.reloadFromSetting(getActivity());
+        mAllPackagesAdapter.notifyDataSetInvalidated();
+        showListView();
+        mExtraOptions.setVisibility(View.GONE);
+        removeFragment();
+    }
+
+    private void transactFragment() {
+        Fragment expandedDesktopExtraPrefs = ExpandedDesktopExtraPrefs.newInstance();
+        FragmentTransaction fragmentTransaction = getChildFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.extra_content, expandedDesktopExtraPrefs,
+                EXPANDED_DESKTOP_PREFERENCE_TAG);
+        fragmentTransaction.commit();
+    }
+
+    private void removeFragment() {
+        FragmentManager fragmentManager = getChildFragmentManager();
+        Fragment fragment = fragmentManager.findFragmentByTag(EXPANDED_DESKTOP_PREFERENCE_TAG);
+        if (fragment != null) {
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            fragmentTransaction.remove(fragment).commit();
+        }
+    }
+
+    private void hideListView() {
+        mUserListView.setVisibility(View.GONE);
+        mEmptyView.setVisibility(View.VISIBLE);
+    }
+
+    private void showListView() {
+        mUserListView.setVisibility(View.VISIBLE);
+        mEmptyView.setVisibility(View.GONE);
+    }
+
+    private void writeValue(String value) {
+        Settings.Global.putString(getContentResolver(), Settings.Global.POLICY_CONTROL, value);
+    }
+
+    private static int getStateForPackage(String packageName) {
+        int state = STATE_DISABLED;
+
+        if (WindowManagerPolicyControl.immersiveStatusFilterMatches(packageName)) {
+            state = STATE_STATUS_HIDDEN;
+        }
+        if (WindowManagerPolicyControl.immersiveNavigationFilterMatches(packageName)) {
+            if (state == STATE_DISABLED) {
+                state = STATE_NAVIGATION_HIDDEN;
+            } else {
+                state = STATE_BOTH_HIDDEN;
+            }
+        }
+
+        return state;
+    }
+
+    @Override
+    public void onRunningStateChanged(boolean running) {
+    }
+
+    @Override
+    public void onPackageListChanged() {
+        mActivityFilter.updateLauncherInfoList();
+        rebuild();
+    }
+
+    @Override
+    public void onRebuildComplete(ArrayList<ApplicationsState.AppEntry> entries) {
+        handleAppEntries(entries);
+    }
+
+    @Override
+    public void onPackageIconChanged() {
+    }
+
+    @Override
+    public void onPackageSizeChanged(String packageName) {
+    }
+
+    @Override
+    public void onAllSizesComputed() {
+    }
+
+    @Override
+    public void onLauncherInfoChanged() {
+
+    }
+
+    @Override
+    public void onLoadEntriesCompleted() {
+
+    }
+
+    private void handleAppEntries(List<ApplicationsState.AppEntry> entries) {
+        String lastSectionIndex = null;
+        ArrayList<String> sections = new ArrayList<String>();
+        ArrayList<Integer> positions = new ArrayList<Integer>();
+        PackageManager pm = getPackageManager();
+        int count = entries.size(), offset = 0;
+
+        for (int i = 0; i < count; i++) {
+            ApplicationInfo info = entries.get(i).info;
+            String label = (String) info.loadLabel(pm);
+            String sectionIndex;
+
+            if (!info.enabled) {
+                sectionIndex = "--"; //XXX
+            } else if (TextUtils.isEmpty(label)) {
+                sectionIndex = "";
+            } else {
+                sectionIndex = label.substring(0, 1).toUpperCase();
+            }
+
+            if (lastSectionIndex == null ||
+                    !TextUtils.equals(sectionIndex, lastSectionIndex)) {
+                sections.add(sectionIndex);
+                positions.add(offset);
+                lastSectionIndex = sectionIndex;
+            }
+
+            offset++;
+        }
+
+        mAllPackagesAdapter.setEntries(entries, sections, positions);
+        mEntryMap.clear();
+        for (ApplicationsState.AppEntry e : entries) {
+            mEntryMap.put(e.info.packageName, e);
+        }
+
+        if (mProgressBar != null) {
+            mProgressBar.setVisibility(View.GONE);
+        }
+
+        if (mExpandedDesktopState != STATE_USER_CONFIGURABLE) {
+            hideListView();
+        }
+    }
+
+    private void rebuild() {
+        ArrayList<ApplicationsState.AppEntry> newEntries = mSession.rebuild(
+                mActivityFilter, ApplicationsState.ALPHA_COMPARATOR);
+        if (newEntries != null) {
+            handleAppEntries(newEntries);
+        }
+    }
+
+    private void save() {
+        if (mExpandedDesktopState == STATE_USER_CONFIGURABLE) {
+            WindowManagerPolicyControl.saveToSettings(getActivity(),
+                    Settings.Global.POLICY_CONTROL);
+        }
+    }
+
+    int getStateDrawable(int state) {
+        switch (state) {
+            case STATE_STATUS_HIDDEN:
+                return R.drawable.ic_settings_extdesk_hidestatusbar;
+            case STATE_NAVIGATION_HIDDEN:
+                return R.drawable.ic_settings_extdesk_hidenavbar;
+            case STATE_BOTH_HIDDEN:
+                return R.drawable.ic_settings_extdesk_hideboth;
+            case STATE_DISABLED:
+            default:
+                return R.drawable.ic_settings_extdesk_hidenone;
+        }
+    }
+
+    @Override
+    public void onSwitchChanged(Switch switchView, boolean isChecked) {
+        if (isChecked) {
+            enableForAll();
+        } else {
+            userConfigurableSettings();
+        }
+    }
+
+    private class AllPackagesAdapter extends BaseAdapter
+            implements AdapterView.OnItemSelectedListener, SectionIndexer {
+
+        private final LayoutInflater inflater;
+        private List<ApplicationsState.AppEntry> entries = new ArrayList<>();
+        private final ModeAdapter mModesAdapter;
+        private String[] mSections;
+        private int[] mPositions;
+
+        public AllPackagesAdapter(Context context) {
+            this.inflater = LayoutInflater.from(context);
+            mModesAdapter = new ModeAdapter(context);
+            mActivityFilter = new ActivityFilter(context.getPackageManager());
+        }
+
+        @Override
+        public int getCount() {
+            return entries.size();
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return entries.get(position);
+        }
+
+        @Override
+        public boolean hasStableIds() {
+            return true;
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return entries.get(position).id;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            ViewHolder holder;
+            if (convertView == null) {
+                holder = new ViewHolder(inflater.inflate(R.layout.expanded_item, parent, false));
+                holder.mode.setAdapter(mModesAdapter);
+                holder.mode.setOnItemSelectedListener(this);
+            } else {
+                holder = (ViewHolder) convertView.getTag();
+            }
+
+            ApplicationsState.AppEntry entry = entries.get(position);
+
+            if (entry == null) {
+                return holder.rootView;
+            }
+
+            holder.title.setText(entry.label);
+            mApplicationsState.ensureIcon(entry);
+            holder.icon.setImageDrawable(entry.icon);
+            holder.mode.setSelection(getStateForPackage(entry.info.packageName), false);
+            holder.mode.setTag(entry);
+            holder.stateIcon.setImageResource(getStateDrawable(
+                    getStateForPackage(entry.info.packageName)));
+            return holder.rootView;
+        }
+
+        private void setEntries(List<ApplicationsState.AppEntry> entries,
+                List<String> sections, List<Integer> positions) {
+            this.entries = entries;
+            if (mUserListView != null && mUserListView.getEmptyView() != mEmptyView) {
+                mUserListView.setEmptyView(mEmptyView);
+            }
+
+            mSections = sections.toArray(new String[sections.size()]);
+            mPositions = new int[positions.size()];
+            for (int i = 0; i < positions.size(); i++) {
+                mPositions[i] = positions.get(i);
+            }
+            notifyDataSetChanged();
+        }
+
+
+        @Override
+        public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            ApplicationsState.AppEntry entry = (ApplicationsState.AppEntry) parent.getTag();
+
+            WindowManagerPolicyControl.removeFromWhiteLists(entry.info.packageName);
+            switch (position) {
+                case STATE_STATUS_HIDDEN:
+                    WindowManagerPolicyControl.addToStatusWhiteList(entry.info.packageName);
+                    break;
+                case STATE_NAVIGATION_HIDDEN:
+                    WindowManagerPolicyControl.addToNavigationWhiteList(entry.info.packageName);
+                    break;
+                case STATE_BOTH_HIDDEN:
+                    WindowManagerPolicyControl.addToStatusWhiteList(entry.info.packageName);
+                    WindowManagerPolicyControl.addToNavigationWhiteList(entry.info.packageName);
+                    break;
+            }
+            save();
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public void onNothingSelected(AdapterView<?> parent) {
+        }
+
+        @Override
+        public int getPositionForSection(int section) {
+            if (section < 0 || section >= mSections.length) {
+                return -1;
+            }
+
+            return mPositions[section];
+        }
+
+        @Override
+        public int getSectionForPosition(int position) {
+            if (position < 0 || position >= getCount()) {
+                return -1;
+            }
+
+            int index = Arrays.binarySearch(mPositions, position);
+
+            /*
+             * Consider this example: section positions are 0, 3, 5; the supplied
+             * position is 4. The section corresponding to position 4 starts at
+             * position 3, so the expected return value is 1. Binary search will not
+             * find 4 in the array and thus will return -insertPosition-1, i.e. -3.
+             * To get from that number to the expected value of 1 we need to negate
+             * and subtract 2.
+             */
+            return index >= 0 ? index : -index - 2;
+        }
+
+        @Override
+        public Object[] getSections() {
+            return mSections;
+        }
+    }
+
+    private static class ViewHolder {
+        private TextView title;
+        private Spinner mode;
+        private ImageView icon;
+        private View rootView;
+        private ImageView stateIcon;
+
+        private ViewHolder(View view) {
+            this.title = (TextView) view.findViewById(R.id.app_name);
+            this.mode = (Spinner) view.findViewById(R.id.app_mode);
+            this.icon = (ImageView) view.findViewById(R.id.app_icon);
+            this.stateIcon = (ImageView) view.findViewById(R.id.state);
+            this.rootView = view;
+
+            view.setTag(this);
+        }
+    }
+
+    private static class ModeAdapter extends BaseAdapter {
+
+        private final LayoutInflater inflater;
+        private boolean hasNavigationBar = true;
+        private final int[] items = {R.string.expanded_hide_nothing, R.string.expanded_hide_status,
+                R.string.expanded_hide_navigation, R.string.expanded_hide_both};
+
+        private ModeAdapter(Context context) {
+            inflater = LayoutInflater.from(context);
+
+            try {
+                hasNavigationBar = WindowManagerGlobal.getWindowManagerService().hasNavigationBar();
+            } catch (RemoteException e) {
+                // Do nothing
+            }
+        }
+
+        @Override
+        public int getCount() {
+            return hasNavigationBar ? 4 : 2;
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return items[position];
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return 0;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            TextView view;
+            if (convertView != null) {
+                view = (TextView) convertView;
+            } else {
+                view = (TextView) inflater.inflate(android.R.layout.simple_spinner_dropdown_item,
+                        parent, false);
+            }
+
+            view.setText(items[position]);
+
+            return view;
+        }
+    }
+
+    private class ActivityFilter implements ApplicationsState.AppFilter {
+
+        private final PackageManager mPackageManager;
+        private final List<String> launcherResolveInfoList = new ArrayList<String>();
+        private boolean onlyLauncher = true;
+
+        private ActivityFilter(PackageManager packageManager) {
+            this.mPackageManager = packageManager;
+
+            updateLauncherInfoList();
+        }
+
+        public void updateLauncherInfoList() {
+            Intent i = new Intent(Intent.ACTION_MAIN);
+            i.addCategory(Intent.CATEGORY_LAUNCHER);
+            List<ResolveInfo> resolveInfoList = mPackageManager.queryIntentActivities(i, 0);
+
+            synchronized (launcherResolveInfoList) {
+                launcherResolveInfoList.clear();
+                for (ResolveInfo ri : resolveInfoList) {
+                    launcherResolveInfoList.add(ri.activityInfo.packageName);
+                }
+            }
+        }
+
+        @Override
+        public void init() {
+        }
+
+        @Override
+        public boolean filterApp(ApplicationsState.AppEntry info) {
+            boolean show = !mAllPackagesAdapter.entries.contains(info.info.packageName);
+            if (show && onlyLauncher) {
+                synchronized (launcherResolveInfoList) {
+                    show = launcherResolveInfoList.contains(info.info.packageName);
+                }
+            }
+            return show;
+        }
+    }
+}

--- a/src/com/android/settings/widget/SwitchBar.java
+++ b/src/com/android/settings/widget/SwitchBar.java
@@ -56,6 +56,9 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
     private String mLabel;
     private String mSummary;
 
+    private int mStateOnLabel = R.string.switch_on_text;
+    private int mStateOffLabel = R.string.switch_off_text;
+
     private ArrayList<OnSwitchChangeListener> mSwitchChangeListeners =
             new ArrayList<OnSwitchChangeListener>();
 
@@ -109,6 +112,14 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
 
         // Default is hide
         setVisibility(View.GONE);
+    }
+
+    public void setOnStateOnLabel(int stringRes) {
+        mStateOnLabel = stringRes;
+    }
+
+    public void setOnStateOffLabel(int stringRes) {
+        mStateOffLabel = stringRes;
     }
 
     public void setTextViewLabel(boolean isChecked) {
@@ -211,6 +222,8 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
     static class SavedState extends BaseSavedState {
         boolean checked;
         boolean visible;
+        int resOnLabel;
+        int resOffLabel;
 
         SavedState(Parcelable superState) {
             super(superState);
@@ -223,6 +236,8 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
             super(in);
             checked = (Boolean)in.readValue(null);
             visible = (Boolean)in.readValue(null);
+            resOnLabel = in.readInt();
+            resOffLabel = in.readInt();
         }
 
         @Override
@@ -230,6 +245,8 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
             super.writeToParcel(out, flags);
             out.writeValue(checked);
             out.writeValue(visible);
+            out.writeInt(resOnLabel);
+            out.writeInt(resOffLabel);
         }
 
         @Override
@@ -237,7 +254,10 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
             return "SwitchBar.SavedState{"
                     + Integer.toHexString(System.identityHashCode(this))
                     + " checked=" + checked
-                    + " visible=" + visible + "}";
+                    + " visible=" + visible
+                    + " resOnLabel = " + resOnLabel
+                    + " resOffLabel = " + resOffLabel
+                    + "}";
         }
 
         public static final Parcelable.Creator<SavedState> CREATOR
@@ -259,6 +279,8 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
         SavedState ss = new SavedState(superState);
         ss.checked = mSwitch.isChecked();
         ss.visible = isShowing();
+        ss.resOnLabel = mStateOnLabel;
+        ss.resOffLabel = mStateOffLabel;
         return ss;
     }
 
@@ -269,6 +291,8 @@ public class SwitchBar extends LinearLayout implements CompoundButton.OnCheckedC
         super.onRestoreInstanceState(ss.getSuperState());
 
         mSwitch.setCheckedInternal(ss.checked);
+        setOnStateOnLabel(ss.resOnLabel);
+        setOnStateOffLabel(ss.resOffLabel);
         setTextViewLabel(ss.checked);
         setVisibility(ss.visible ? View.VISIBLE : View.GONE);
         mSwitch.setOnCheckedChangeListener(ss.visible ? this : null);


### PR DESCRIPTION
Settings: Bringup expanded desktop and implement per-user configuration.

Change-Id: Ib673d278d23423fe6885c73f1eb3dd858633e5b6

Settings: Don't load per-app extdesk into memory if not USER_CONFIGURABLE.

Change-Id: Iae4857e0cd95d75ae29222bb45a8fdcf0ff1ec48

Settings: Only save settings on destroy if we're user configurable.

Change-Id: Ie459053b4614f818dfa19948709a3dd0fdb8f427

Settings: Fix off-by-one SectionIndexer in Expanded Desktop.

Change-Id: I7bdd1081114b40cc2ab6372d16bb247401f83a86

Settings: Create default expanded desktop style fragment.

Change-Id: Ia5bebb45a953c2a8efdffbab2ddcbfa3d3c3d486